### PR TITLE
chore: update nextjs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 package-lock.json
 .next/
 .env*
+node_modules

--- a/next.config.js
+++ b/next.config.js
@@ -41,7 +41,7 @@ module.exports = {
         new HoneybadgerSourceMapPlugin({
           apiKey: HONEYBADGER_API_KEY,
           assetsUrl: HONEYBADGER_ASSETS_URL,
-          revision: HONEYBADGER_REVISION
+          revision: HONEYBADGER_REVISION,
         })
       )
     }

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,5 @@
 // Use the hidden-source-map option when you don't want the source maps to be
 // publicly available on the servers, only to the error reporting
-const withSourceMaps = require('@zeit/next-source-maps')()
 const HoneybadgerSourceMapPlugin = require('@honeybadger-io/webpack')
 const { execSync } = require('child_process');
 
@@ -14,7 +13,8 @@ const {
 
 const HONEYBADGER_REVISION = execSync('git rev-parse HEAD').toString().trim()
 
-module.exports = withSourceMaps({
+module.exports = {
+  productionSourceMaps: true,
   env: {
     HONEYBADGER_API_KEY,
     HONEYBADGER_REVISION,
@@ -32,15 +32,20 @@ module.exports = withSourceMaps({
       HONEYBADGER_ASSETS_URL &&
       NODE_ENV === 'production'
     ) {
+      // `config.devtool` must be 'hidden-source-map' or 'eval-source-map'
+      // Next.js uses regular `source-map` which doesnt pass its sourcemaps to Webpack.
+      // https://github.com/vercel/next.js/blob/89ec21ed686dd79a5770b5c669abaff8f55d8fef/packages/next/build/webpack/config/blocks/base.ts#L40
+      config.devtool = 'hidden-source-map'
+
       config.plugins.push(
         new HoneybadgerSourceMapPlugin({
           apiKey: HONEYBADGER_API_KEY,
           assetsUrl: HONEYBADGER_ASSETS_URL,
-          revision: HONEYBADGER_REVISION,
+          revision: HONEYBADGER_REVISION
         })
       )
     }
 
     return config
   },
-})
+}

--- a/next.config.js
+++ b/next.config.js
@@ -32,7 +32,7 @@ module.exports = {
       HONEYBADGER_ASSETS_URL &&
       NODE_ENV === 'production'
     ) {
-      // `config.devtool` must be 'hidden-source-map' or 'eval-source-map'
+      // `config.devtool` must be 'hidden-source-map' or 'source-map' to properly pass sourcemaps.
       // Next.js uses regular `source-map` which doesnt pass its sourcemaps to Webpack.
       // https://github.com/vercel/next.js/blob/89ec21ed686dd79a5770b5c669abaff8f55d8fef/packages/next/build/webpack/config/blocks/base.ts#L40
       config.devtool = 'hidden-source-map'

--- a/package.json
+++ b/package.json
@@ -10,9 +10,8 @@
   "dependencies": {
     "@honeybadger-io/js": "^3.0.0",
     "@honeybadger-io/webpack": "^1.2.0",
-    "@zeit/next-source-maps": "0.0.4-canary.1",
     "next": "latest",
-    "react": "^16.14.0",
-    "react-dom": "^16.14.0"
+    "react": ">= 17.0.1",
+    "react-dom": ">= 17.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@honeybadger-io/js": "^3.0.0",
-    "@honeybadger-io/webpack": "^1.2.0",
+    "@honeybadger-io/webpack": "^1.3.0-beta.0",
     "next": "latest",
     "react": ">= 17.0.1",
     "react-dom": ">= 17.0.1"


### PR DESCRIPTION
## Status

Ready

## Summary of changes

### Adds

- Adds `node_modules` to `.gitignore`
- Adds the `productionSourceMaps: true` flag.
- Adds the specified `config.devtool = "hidden-source-map"` for proper
sourcemap creation.

### Fixes

- Upgrade React to `>= 17.0.1` since it is what Next says to do! https://err.sh/next.js/react-version

### Removals

- Removes the `@zeit/next-source-maps` package in favor of using the
new sourcemap flag. https://github.com/vercel/next.js/pull/20267

## Testing

The above was all tested in a new app, and with the master version of the Webpack plugin. The master version is confirmed working with Webpack 4 / 5.

Even though it says `productionBrowserSourcemaps` it still passes the js through webpack for the server side js and will upload the server sourcemaps.

https://nextjs.org/docs/advanced-features/source-maps

<details>
<summary> Logs of a deploy with a new app</summary>

```bash
➜  nextjs-example-with-honeybadger git:(chore/upgrade-nextjs) ✗ yarn build
yarn run v1.22.10
$ next build
info  - Loaded env from /Users/konnorrogers/projects/oss/nextjs-example-with-honeybadger/.env
info  - Creating an optimized production build .

info  - Creating an optimized production build ..

info  - Creating an optimized production build .Uploaded pages/server/test4.js.map to Honeybadger API
info  - Creating an optimized production build ..Uploaded static/chunks/pages/server/test4-5c79c69de9744289db43.js.map to Honeybadger API
Uploaded static/chunks/pages/client/test7-fa7fae48a5b6992b6a4b.js.map to Honeybadger API
info  - Creating an optimized production build ...Uploaded static/chunks/pages/server/test2-f284cc82ecdce9bf4ddc.js.map to Honeybadger API
Uploaded pages/client/test5.js.map to Honeybadger API
Uploaded pages/server/test2.js.map to Honeybadger API
Uploaded static/chunks/webpack-50bee04d1dc61f8adf5b.js.map to Honeybadger API
Uploaded pages/client/test1.js.map to Honeybadger API
Uploaded static/chunks/pages/index-a401cd124aef398c560e.js.map to Honeybadger API
Uploaded static/chunks/pages/client/test5-f863a09060a7d930c2a7.js.map to Honeybadger API
Uploaded static/chunks/b1542cc239bf56c8a14913c0a930efe682b5cf86.407db31abe66d51137a0.js.map to Honeybadger API
Uploaded pages/client/test6.js.map to Honeybadger API
Uploaded static/chunks/pages/client/test3-18a0f0bf89a5d2098a1d.js.map to Honeybadger API
info  - Creating an optimized production build .Uploaded pages/_app.js.map to Honeybadger API
Uploaded static/chunks/3ef630e34cd10ba68f9d468ac363ff81c534e1e9.b34bca09bc5b938f8f6a.js.map to Honeybadger API
Uploaded static/chunks/main-5f5a175c650de61ce3fe.js.map to Honeybadger API
Uploaded pages/server/test1.js.map to Honeybadger API
Uploaded on-error-server.js.js.map to Honeybadger API
Uploaded pages/client/test8.js.map to Honeybadger API
Uploaded static/chunks/polyfills-ad30d1320810fa304e64.js.map to Honeybadger API
Uploaded pages/client/test4.js.map to Honeybadger API
Uploaded pages/_error.js.map to Honeybadger API
Uploaded pages/client/test7.js.map to Honeybadger API
Uploaded static/chunks/pages/client/test1-594de535bd88331c398c.js.map to Honeybadger API
Uploaded pages/client/test2.js.map to Honeybadger API
info  - Creating an optimized production build ..Uploaded pages/client/test3.js.map to Honeybadger API
Uploaded pages/server/test3.js.map to Honeybadger API
Uploaded init-server.js.js.map to Honeybadger API
Uploaded static/chunks/pages/server/test3-feba04b864835b3d16a3.js.map to Honeybadger API
Uploaded static/chunks/pages/client/test4-5578ee454f71ce9486e5.js.map to Honeybadger API
Uploaded static/chunks/pages/server/test1-ea3ac3406c6341926a83.js.map to Honeybadger API
Uploaded static/chunks/pages/client/test2-a19a76cdcbac88e9a992.js.map to Honeybadger API
Uploaded static/chunks/pages/client/test8-992da195954cdcc98368.js.map to Honeybadger API
Uploaded static/chunks/pages/_error-9c356f6811401fe8c466.js.map to Honeybadger API
Uploaded static/chunks/pages/client/test6-5ebd4dfe403d7dad7c60.js.map to Honeybadger API
Uploaded static/chunks/5b6f950a52454da5f4b23d4c6766dc18806479d2.ebefd935aa9eadf7826f.js.map to Honeybadger API
Uploaded static/chunks/pages/_app-2dbd3b2c4e04cbd5636c.js.map to Honeybadger API
Uploaded pages/index.js.map to Honeybadger API
info  - Creating an optimized production build ...Uploaded static/chunks/framework.e2fe4ae6b85b1c7a6eb1.js.map to Honeybadger API
Uploaded pages/_document.js.map to Honeybadger API
info  - Creating an optimized production build
info  - Compiled successfully
info  - Collecting page data
info  - Generating static pages (6/6)
info  - Finalizing page optimization

Page                                                           Size     First Load JS
┌ ○ /                                                          2.69 kB        75.5 kB
├   /_app                                                      0 B            72.9 kB
├ λ /404                                                       3.78 kB        76.6 kB
├ λ /client/test1                                              316 B          73.2 kB
├ λ /client/test2                                              321 B          73.2 kB
├ λ /client/test3                                              324 B          73.2 kB
├ ○ /client/test4                                              305 B          73.2 kB
├ ○ /client/test5                                              336 B          73.2 kB
├ ○ /client/test6                                              319 B          73.2 kB
├ ○ /client/test7                                              600 B          73.5 kB
├ ○ /client/test8                                              356 B          73.2 kB
├ λ /server/test1                                              313 B          73.2 kB
├ λ /server/test2                                              320 B          73.2 kB
├ λ /server/test3                                              322 B          73.2 kB
└ λ /server/test4                                              322 B          73.2 kB
+ First Load JS shared by all                                  72.9 kB
  ├ chunks/3ef630e34cd10ba68f9d468ac363ff81c534e1e9.b34bca.js  11.3 kB
  ├ chunks/5b6f950a52454da5f4b23d4c6766dc18806479d2.ebefd9.js  2.47 kB
  ├ chunks/b1542cc239bf56c8a14913c0a930efe682b5cf86.407db3.js  7.34 kB
  ├ chunks/framework.e2fe4a.js                                 41.8 kB
  ├ chunks/main.5f5a17.js                                      6.67 kB
  ├ chunks/pages/_app.2dbd3b.js                                2.61 kB
  └ chunks/webpack.50bee0.js                                   751 B

λ  (Server)  server-side renders at runtime (uses getInitialProps or getServerSideProps)
○  (Static)  automatically rendered as static HTML (uses no initial props)
●  (SSG)     automatically generated as static HTML + JSON (uses getStaticProps)
   (ISR)     incremental static regeneration (uses revalidate in getStaticProps)

✨  Done in 5.01s.

```

</details>

## Related issues

Closes #3 

## Additional comments

@joshuap I don't know your stance on source maps, I accidentally stumbled upon a whole web of source map related conversations in Rails and went with the `hidden-source-map` instead of the `eval-source-map`. `eval-source-map` enables references to source maps for clients and is my personal preference. My personal belief is in an open web, and obfuscation via transpilation is poor security. Anyways, just my $0.02. Feel free to chime in!

reference on source maps:

https://webpack.js.org/configuration/devtool/