### PR TITLE
Update example with most recent NextJS and server-side sourcemaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is a simple example showing how to use
 [Honeybadger](https://www.honeybadger.io/for/javascript) to catch & report
-errors on both client + server side.
+errors on both client + server side in Next.js.
 
 - `_app.js` renders on both the server and client. It initializes Honeybadger to catch any unhandled exceptions
 - `_error.js` is rendered by Next.js while handling certain types of exceptions for you. It is overridden so those exceptions can be passed along to Honeybadger
@@ -47,6 +47,14 @@ yarn dev
 
 Your app should be up and running on [http://localhost:3000](http://localhost:3000)! If it doesn't work, email us at support@honeybadger.io.
 
+## Testing error reporting locally
+When enabled in development mode, error handling [works differently than in production](https://nextjs.org/docs/advanced-features/error-handling). To test error reporting locally, you should run a production build, i.e.
+
+```bash
+npm run build
+npm start
+```
+
 ## Deployment
 
 Deploy to [Vercel](https://vercel.com):
@@ -61,8 +69,6 @@ You must add the following configuration values when deploying:
 ## Notes
 
 - By default, neither sourcemaps nor error tracking is enabled in development mode (see Configuration).
-
-- When enabled in development mode, error handling [works differently than in production](https://nextjs.org/docs#custom-error-handling) as `_error.js` is never actually called.
 
 - The build output will contain warning about unhandled Promise rejections. This is caused by the test pages, and is expected.
 

--- a/next.config.js
+++ b/next.config.js
@@ -34,7 +34,6 @@ module.exports = {
       // https://github.com/vercel/next.js/blob/89ec21ed686dd79a5770b5c669abaff8f55d8fef/packages/next/build/webpack/config/blocks/base.ts#L40
       // Use the hidden-source-map option when you don't want the source maps to be
       // publicly available on the servers, only to the error reporting
-      // TODO: TEST SOURCE-MAP VS HIDDEN-SOURCE-MAP
       config.devtool = 'hidden-source-map'
 
       config.plugins.push(

--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,3 @@
-// Use the hidden-source-map option when you don't want the source maps to be
-// publicly available on the servers, only to the error reporting
 const HoneybadgerSourceMapPlugin = require('@honeybadger-io/webpack')
 const { execSync } = require('child_process');
 
@@ -14,7 +12,6 @@ const {
 const HONEYBADGER_REVISION = execSync('git rev-parse HEAD').toString().trim()
 
 module.exports = {
-  productionSourceMaps: true,
   env: {
     HONEYBADGER_API_KEY,
     HONEYBADGER_REVISION,
@@ -35,6 +32,9 @@ module.exports = {
       // `config.devtool` must be 'hidden-source-map' or 'source-map' to properly pass sourcemaps.
       // Next.js uses regular `source-map` which doesnt pass its sourcemaps to Webpack.
       // https://github.com/vercel/next.js/blob/89ec21ed686dd79a5770b5c669abaff8f55d8fef/packages/next/build/webpack/config/blocks/base.ts#L40
+      // Use the hidden-source-map option when you don't want the source maps to be
+      // publicly available on the servers, only to the error reporting
+      // TODO: TEST SOURCE-MAP VS HIDDEN-SOURCE-MAP
       config.devtool = 'hidden-source-map'
 
       config.plugins.push(

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,5 +1,3 @@
-import React from 'react'
-import App from 'next/app'
 import Honeybadger from '@honeybadger-io/js'
 
 // https://docs.honeybadger.io/lib/javascript/reference/configuration.html
@@ -7,10 +5,11 @@ Honeybadger.configure({
   apiKey: process.env.HONEYBADGER_API_KEY,
   revision: process.env.HONEYBADGER_REVISION,
   environment: process.env.NODE_ENV,
+  // TODO: DIFFERENT FOR SERVER-SIDE?
   projectRoot: 'webpack://_N_E/./',
 
   // Uncomment to report errors in development:
-  reportData: true,
+  // reportData: true,
 })
 
 // This is handy for testing; remove it in production.
@@ -18,16 +17,10 @@ if (typeof window !== 'undefined') {
   window.Honeybadger = Honeybadger
 }
 
-class MyApp extends App {
-  render() {
-    const { Component, pageProps } = this.props
-
-    // Workaround for https://github.com/zeit/next.js/issues/8592
-    const { err } = this.props
-    const modifiedPageProps = { ...pageProps, err }
-
-    return <Component {...modifiedPageProps} />
-  }
+export default function MyApp({ Component, pageProps, err }) {
+  // Uncomment the workaround below if using Next.js version prior to 12.2.1
+  // getInitialProps is not called in case of https://github.com/zeit/next.js/issues/8592
+  //
+  // pageProps.err = err
+  return <Component {...pageProps} />
 }
-
-export default MyApp

--- a/pages/_error.js
+++ b/pages/_error.js
@@ -1,24 +1,23 @@
-import React from 'react'
 import Error from 'next/error'
 import Honeybadger from '@honeybadger-io/js'
 
 const MyError = ({ statusCode, hasGetInitialPropsRun, err }) => {
-  if (!hasGetInitialPropsRun && err) {
-    // getInitialProps is not called in case of
-    // https://github.com/zeit/next.js/issues/8592. As a workaround, we pass
-    // err via _app.js so it can be captured
-    Honeybadger.notify(err)
-  }
-
+  // Uncomment the workaround below if using Next.js version prior to 12.2.1
+  // getInitialProps is not called in case of https://github.com/zeit/next.js/issues/8592
+  //
+  // if (!hasGetInitialPropsRun && err) {
+  //   Honeybadger.notify(err)
+  // }
   return <Error statusCode={statusCode} />
 }
 
 MyError.getInitialProps = async ({ res, err, asPath }) => {
   const errorInitialProps = await Error.getInitialProps({ res, err })
 
-  // Workaround for https://github.com/zeit/next.js/issues/8592, mark when
-  // getInitialProps has run
-  errorInitialProps.hasGetInitialPropsRun = true
+  // Uncomment the workaround below if using Next.js version prior to 12.2.1
+  // getInitialProps is not called in case of https://github.com/zeit/next.js/issues/8592
+  //
+  // errorInitialProps.hasGetInitialPropsRun = true
 
   if (res) {
     // Running on the server, the response object is available.

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import Link from 'next/link'
 
 const Index = () => (
@@ -13,127 +12,126 @@ const Index = () => (
       <strong>Important:</strong> exceptions in development mode take a
       different path than in production. These tests should be run on a
       production build (i.e. 'next build').{' '}
-      <a href="https://nextjs.org/docs#custom-error-handling">Read more</a>
+      <a href="https://nextjs.org/docs/advanced-features/error-handling" target="_blank">Read more</a>
     </p>
-    <ul>
-      <li>Server exceptions</li>
-      <ul>
-        <li>
-          getInitialProps throws an Error. This should cause _error.js to render
-          and record Error('Client Test 1') in Honeybadger.{' '}
-          <a href="/server/test1" target="_blank">
-            Open in a new tab
-          </a>
-        </li>
-        <li>
-          getInitialProps returns a Promise that rejects. This should cause
-          _error.js to render and record Error('Server Test 2') in Honeybadger.{' '}
-          <a href="/server/test2" target="_blank">
-            Open in a new tab
-          </a>
-        </li>
-        <li>
-          getInitialProps calls a Promise that rejects, but does not handle the
-          rejection or await its result (returning synchronously).{' '}
-          Honeybadger shouldrecord Error('Server Test 3').{' '}
-          <a href="/server/test3" target="_blank">
-            Open in a new tab
-          </a>
-        </li>
-        <li>
-          There is a top-of-module Promise that rejects, but its result is not
-          awaited. Honeybadger should record Error('Server Test 4'). Note this will
-          also be recorded on the client side, once the page is hydrated.{' '}
-          <a href="/server/test4" target="_blank">
-            Open in a new tab
-          </a>
-        </li>
-      </ul>
 
-      <li>Client exceptions</li>
-      <ul>
-        <li>
-          getInitialProps throws an Error. This should cause _error.js to render
-          and record Error('Client Test 1') in Honeybadger.{' '}
-          <Link href="/client/test1">
-            <a>Perform client side navigation</a>
-          </Link>
-        </li>
-        <li>
-          getInitialProps returns a Promise that rejects. This should cause
-          _error.js to render and record Error('Client Test 2') in Honeybadger.{' '}
-          <Link href="/client/test2">
-            <a>Perform client side navigation</a>
-          </Link>
-        </li>
-        <li>
-          getInitialProps calls a Promise that rejects, but does not handle the
-          rejection or await its result (returning synchronously). Honeybadger should
-          record Error('Client Test 3').{' '}
-          <Link href="/client/test3">
-            <a>Perform client side navigation</a>
-          </Link>
-        </li>
-        <li>
-          There is a top-of-module Promise that rejects, but its result is not
-          awaited. Honeybadger should record Error('Client Test 4').{' '}
-          <Link href="/client/test4">
-            <a>Perform client side navigation</a>
-          </Link>{' '}
-          or{' '}
-          <a href="/client/test4" target="_blank">
-            Open in a new tab
-          </a>
-        </li>
-        <li>
-          There is a top-of-module exception. _error.js should render and record
-          ReferenceError('process is not defined') in Honeybadger.{' '}
-          <Link href="/client/test5">
-            <a>Perform client side navigation</a>
-          </Link>{' '}
-          or{' '}
-          <a href="/client/test5" target="_blank">
-            Open in a new tab
-          </a>
-        </li>
-        <li>
-          There is an exception during React lifecycle that is caught by
-          Next.js's React Error Boundary. In this case, when the component
-          mounts. This should cause _error.js to render and record Error('Client
-          Test 6') in Honeybadger.{' '}
-          <Link href="/client/test6">
-            <a>Perform client side navigation</a>
-          </Link>{' '}
-          or{' '}
-          <a href="/client/test6" target="_blank">
-            Open in a new tab
-          </a>
-        </li>
-        <li>
-          There is an unhandled Promise rejection during React lifecycle. In
-          this case, when the component mounts. Honeybadger should record
-          Error('Client Test 7').{' '}
-          <Link href="/client/test7">
-            <a>Perform client side navigation</a>
-          </Link>{' '}
-          or{' '}
-          <a href="/client/test7" target="_blank">
-            Open in a new tab
-          </a>
-        </li>
-        <li>
-          An Error is thrown from an event handler. Honeybadger should record
-          Error('Client Test 8').{' '}
-          <Link href="/client/test8">
-            <a>Perform client side navigation</a>
-          </Link>{' '}
-          or{' '}
-          <a href="/client/test8" target="_blank">
-            Open in a new tab
-          </a>
-        </li>
-      </ul>
-    </ul>
+    <h3>Server exceptions</h3>
+    <ol>
+      <li>
+        getInitialProps throws an Error. This should cause _error.js to render
+        and record Error('Server Test 1') in Honeybadger.{' '}
+        <a href="/server/test1" target="_blank">
+          Open in a new tab
+        </a>
+      </li>
+      <li>
+        getInitialProps returns a Promise that rejects. This should cause
+        _error.js to render and record Error('Server Test 2') in Honeybadger.{' '}
+        <a href="/server/test2" target="_blank">
+          Open in a new tab
+        </a>
+      </li>
+      <li>
+        getInitialProps calls a Promise that rejects, but does not handle the
+        rejection or await its result (returning synchronously).{' '}
+        Honeybadger shouldrecord Error('Server Test 3').{' '}
+        <a href="/server/test3" target="_blank">
+          Open in a new tab
+        </a>
+      </li>
+      <li>
+        There is a top-of-module Promise that rejects, but its result is not
+        awaited. Honeybadger should record Error('Server Test 4'). Note this will
+        also be recorded on the client side, once the page is hydrated.{' '}
+        <a href="/server/test4" target="_blank">
+          Open in a new tab
+        </a>
+      </li>
+    </ol>
+
+    <h3>Client exceptions</h3>
+    <ol>
+      <li>
+        getInitialProps throws an Error. This should cause _error.js to render
+        and record Error('Client Test 1') in Honeybadger.{' '}
+        <Link legacyBehavior href="/client/test1">
+          <a>Perform client side navigation</a>
+        </Link>
+      </li>
+      <li>
+        getInitialProps returns a Promise that rejects. This should cause
+        _error.js to render and record Error('Client Test 2') in Honeybadger.{' '}
+        <Link legacyBehavior href="/client/test2">
+          <a>Perform client side navigation</a>
+        </Link>
+      </li>
+      <li>
+        getInitialProps calls a Promise that rejects, but does not handle the
+        rejection or await its result (returning synchronously). Honeybadger should
+        record Error('Client Test 3').{' '}
+        <Link legacyBehavior href="/client/test3">
+          <a>Perform client side navigation</a>
+        </Link>
+      </li>
+      <li>
+        There is a top-of-module Promise that rejects, but its result is not
+        awaited. Honeybadger should record Error('Client Test 4').{' '}
+        <Link legacyBehavior href="/client/test4">
+          <a>Perform client side navigation</a>
+        </Link>{' '}
+        or{' '}
+        <a href="/client/test4" target="_blank">
+          Open in a new tab
+        </a>
+      </li>
+      <li>
+        There is a top-of-module exception. _error.js should render and record
+        ReferenceError('process is not defined') in Honeybadger.{' '}
+        <Link legacyBehavior href="/client/test5">
+          <a>Perform client side navigation</a>
+        </Link>{' '}
+        or{' '}
+        <a href="/client/test5" target="_blank">
+          Open in a new tab
+        </a>
+      </li>
+      <li>
+        There is an exception during React lifecycle that is caught by
+        Next.js's React Error Boundary. In this case, when the component
+        mounts. This should cause _error.js to render and record Error('Client
+        Test 6') in Honeybadger.{' '}
+        <Link legacyBehavior href="/client/test6">
+          <a>Perform client side navigation</a>
+        </Link>{' '}
+        or{' '}
+        <a href="/client/test6" target="_blank">
+          Open in a new tab
+        </a>
+      </li>
+      <li>
+        There is an unhandled Promise rejection during React lifecycle. In
+        this case, when the component mounts. Honeybadger should record
+        Error('Client Test 7').{' '}
+        <Link legacyBehavior href="/client/test7">
+          <a>Perform client side navigation</a>
+        </Link>{' '}
+        or{' '}
+        <a href="/client/test7" target="_blank">
+          Open in a new tab
+        </a>
+      </li>
+      <li>
+        An Error is thrown from an event handler. Honeybadger should record
+        Error('Client Test 8').{' '}
+        <Link legacyBehavior href="/client/test8">
+          <a>Perform client side navigation</a>
+        </Link>{' '}
+        or{' '}
+        <a href="/client/test8" target="_blank">
+          Open in a new tab
+        </a>
+      </li>
+    </ol>
   </div>
 )
 


### PR DESCRIPTION
In the process of working on https://github.com/honeybadger-io/docs/issues/190, I thought it would be useful to get this repo working with the most recent version of NextJS, including getting server-side sourcemaps working, which has [been an issue in the past](https://github.com/honeybadger-io/nextjs-with-honeybadger/issues/7). 

In the current state of this PR, I get all the example errors reported to Honeybadger, with sourcemaps applied, either when I'm running the app locally (ie `npm run build && npm start`) or when I deploy to Heroku. I have issues when deploying to Vercel (see below), but I believe those are longstanding issues and are not caused by this PR. 

---------------------------
When I deploy to Vercel, I can't get server-side errors at all (on my branch or on master). All the server pages give me a 404. The Vercel log looks like this: 
<img width="1152" alt="Screen Shot 2022-12-28 at 10 49 57 AM" src="https://user-images.githubusercontent.com/16493493/209842735-7a2ed316-3bb0-4c88-ba06-185a34c6a221.png">
So it appears that the function is getting called and erroring as I'd expect (500) but then displaying a 404. I don't yet understand why the "Edge Status" differs from the "Function Status". 

I did confirm that there's nothing wrong with the routing, by adding another page within the `/server` folder that does not throw an error. That page loads fine on Vercel, so it's definitely related to error handling and not a true 404. 

`_error.js` is getting called, however it's getting called for the 404, not the 500. The `err` object is null. 
<img width="439" alt="Screen Shot 2022-12-29 at 9 55 36 AM" src="https://user-images.githubusercontent.com/16493493/209970842-5dcc0a6f-af84-4f89-b5cd-d88dfca2f7a1.png">

Based on [comments from @subzero10](https://github.com/honeybadger-io/nextjs-with-honeybadger/issues/7#issuecomment-1035518649) I do not think these Vercel issues were introduced by this PR. 