### PR TITLE
Update hb version

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "start": "next start"
   },
   "dependencies": {
-    "@honeybadger-io/js": "^3.2.0",
-    "@honeybadger-io/webpack": "^1.5.1",
+    "@honeybadger-io/js": "^5.1.1",
+    "@honeybadger-io/webpack": "^5.1.0",
     "next": "latest",
     "react": ">= 17.0.1",
     "react-dom": ">= 17.0.1"


### PR DESCRIPTION
In reviewing https://github.com/honeybadger-io/honeybadger-js/issues/1020, I wanted to test this example repo against honeybadger-js v5. 

So far I've found no issues here, but we may as well have an up-to-date example. 